### PR TITLE
Use symbols for placeholder

### DIFF
--- a/lib/placeholder.js
+++ b/lib/placeholder.js
@@ -1,6 +1,8 @@
-const __ = {
-  '@@functional/placeholder': true
-}
+const __ = Symbol('@@lando/placeholder')
+
+export const isPlaceholder = x =>
+  typeof x === 'symbol'
+  && x === __
 
 export default __
 

--- a/test/placeholder.js
+++ b/test/placeholder.js
@@ -1,7 +1,7 @@
 import test from 'ava'
-import __ from '../lib/placeholder'
+import __, { isPlaceholder } from '../lib/placeholder'
 
 test('is placeholder', t => {
-  t.true(__['@@functional/placeholder'])
+  t.true(isPlaceholder(__))
 })
 


### PR DESCRIPTION
This PR implements Symbols for placeholder instead of using property objects.

closes #6 